### PR TITLE
fix(ProgressLevel): use correct rating bands for progress bar

### DIFF
--- a/frontend/src/components/ProgressLevel.tsx
+++ b/frontend/src/components/ProgressLevel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getRatingLevel } from "../utils";
+import { getRatingLevel, getRatingBand } from "../utils";
 
 interface ProgressLevelProps {
   cfRating: number | null;
@@ -7,8 +7,8 @@ interface ProgressLevelProps {
 
 const ProgressLevel: React.FC<ProgressLevelProps> = ({ cfRating }) => {
   const rating = cfRating ?? 0;
-  const bandCeil = Math.ceil(rating / 200) * 200;
-  const progressPercent = (rating % 200) / 2;
+  const [bandFloor, bandCeil] = getRatingBand(rating);
+  const progressPercent = (rating - bandFloor) / (bandCeil + 1 - bandFloor) * 100;
 
   return (
     <div>
@@ -20,13 +20,13 @@ const ProgressLevel: React.FC<ProgressLevelProps> = ({ cfRating }) => {
         <div className="flex items-center justify-between mb-4">
           <div className="text-white font-medium">
             {getRatingLevel(cfRating)} to{" "}
-            {getRatingLevel(cfRating !== null ? cfRating + 200 : null)}
+            {getRatingLevel(bandCeil + 1)}
           </div>
         </div>
 
         <div className="mb-4">
           <div className="text-sm text-gray-400 mb-2">
-            Rating: {rating}/{bandCeil}
+            Rating: {rating}/{bandCeil + 1}
           </div>
           <div className="w-full bg-gray-700 rounded-full h-2">
             <div
@@ -41,7 +41,7 @@ const ProgressLevel: React.FC<ProgressLevelProps> = ({ cfRating }) => {
 
         <div className="flex items-center justify-between">
           <div className="text-sm text-gray-400">
-            🏆 Next milestone at {bandCeil}
+            🏆 Next milestone at {bandCeil + 1}
           </div>
         </div>
       </div>

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -7,7 +7,9 @@ export function getRatingLevel(rating: number | null): string {
   if (rating < 2100) return "Candidate Master";
   if (rating < 2300) return "Master";
   if (rating < 2400) return "International Master";
-  return "Grandmaster";
+  if (rating < 2600) return "Grandmaster";
+  if (rating < 3000) return "International Grandmaster";
+  return "Legendary Grandmaster";
 }
 
 export function getRatingColor(rating: number | null): string {
@@ -20,4 +22,18 @@ export function getRatingColor(rating: number | null): string {
   if (rating < 2300) return "text-yellow-400";
   if (rating < 2400) return "text-orange-400";
   return "text-red-400";
+}
+
+export function getRatingBand(rating: number | null): [number, number] {
+  rating = rating ?? 0;
+  if (rating < 1200) return [0, 1199];
+  if (rating < 1400) return [1200, 1399];
+  if (rating < 1600) return [1400, 1599];
+  if (rating < 1900) return [1600, 1899];
+  if (rating < 2100) return [1900, 2099];
+  if (rating < 2300) return [2100, 2299];
+  if (rating < 2400) return [2300, 2399];
+  if (rating < 2600) return [2400, 2599];
+  if (rating < 3000) return [2600, 2999];
+  return [3000, 3999];
 }


### PR DESCRIPTION
- add getRatingBand method in utils.
- use floor and ceil values of rating band to calculate progress.